### PR TITLE
Add example for constant request rate

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+cmake_minimum_required(VERSION 3.18)
+project(constant_rate_openai_example LANGUAGES CXX)
+
+add_executable(constant_rate_openai constant_rate_openai.cpp)
+
+# Use the client backend library built by perf_analyzer
+# TRITON_HTTP_STATIC_LIB and CURL::libcurl are found in src/CMakeLists
+find_package(CURL REQUIRED)
+
+target_link_libraries(constant_rate_openai PRIVATE
+    client-backend-library
+    ${TRITON_HTTP_STATIC_LIB}
+    CURL::libcurl)
+
+target_include_directories(constant_rate_openai PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)
+
+set_target_properties(constant_rate_openai PROPERTIES
+    CXX_STANDARD 20
+    POSITION_INDEPENDENT_CODE ON)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,65 @@
+<!--
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+# OpenAI constant rate example
+
+This example sends asynchronous chat completion requests to an OpenAI API
+compatible server at a constant rate. It uses the same client backend that
+`perf_analyzer` relies on.
+
+## Build
+
+First build perf_analyzer and its libraries. A minimal build can be done from
+the repository root:
+
+```bash
+mkdir build
+cmake -B build -S .
+cmake --build build -- -j8
+```
+
+After the build finishes, compile the example:
+
+```bash
+cmake -B build/examples -S examples -DCMAKE_PREFIX_PATH=$(pwd)/build/perf_analyzer/src/perf-analyzer-build
+cmake --build build/examples -- -j8
+```
+
+The `CMAKE_PREFIX_PATH` argument lets CMake locate the libraries built with
+perf_analyzer.
+
+## Run
+
+Start your OpenAI compatible server (for example `localhost:5000`) and run the
+example binary:
+
+```bash
+build/examples/constant_rate_openai
+```
+
+The program reads `examples/inputs.json` and will issue 64 requests at a rate of
+8 requests per second. Responses are printed to standard output.

--- a/examples/constant_rate_openai.cpp
+++ b/examples/constant_rate_openai.cpp
@@ -1,0 +1,49 @@
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "client_backend/openai/openai_client.h"
+
+using namespace triton::perfanalyzer::clientbackend::openai;
+
+std::string
+LoadFile(const std::string& path)
+{
+  std::ifstream in(path);
+  return std::string(
+      (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+int
+main(int argc, char** argv)
+{
+  const std::string url = "http://localhost:5000";
+  const std::string endpoint = "v1/chat/completions";
+  std::string request_body = LoadFile("examples/inputs.json");
+
+  ChatCompletionClient client(url, endpoint, true);
+
+  auto on_response = [](InferResult* result) {
+    std::vector<uint8_t> buf;
+    if (result->RawData("", buf).IsOk()) {
+      std::cout << std::string(buf.begin(), buf.end()) << std::endl;
+    }
+    delete result;
+  };
+
+  const double rate = 8.0;  // requests per second
+  const size_t request_count = 64;
+  auto period = std::chrono::duration<double>(1.0 / rate);
+
+  for (size_t i = 0; i < request_count; ++i) {
+    client.AsyncInfer(on_response, request_body, std::to_string(i), {});
+    std::this_thread::sleep_for(period);
+  }
+
+  // Allow time for all responses to complete
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+  return 0;
+}

--- a/examples/inputs.json
+++ b/examples/inputs.json
@@ -1,0 +1,5 @@
+{
+  "model": "facebook/opt-125m",
+  "messages": [{ "role": "user", "content": "Who wrote the play Romeo and Juliet?" }],
+  "max_tokens": 32
+}


### PR DESCRIPTION
## Summary
- add `constant_rate_openai.cpp` and example input JSON
- provide CMake file and README with build instructions

## Testing
- `pre-commit run --files examples/constant_rate_openai.cpp examples/inputs.json examples/CMakeLists.txt examples/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68776d5c9d848326b80b8b9893ee5ff2